### PR TITLE
Update cod-cab8ud_p9i7y5-de1603.xml

### DIFF
--- a/p9i7y5-de1603/cod-cab8ud_p9i7y5-de1603.xml
+++ b/p9i7y5-de1603/cod-cab8ud_p9i7y5-de1603.xml
@@ -370,11 +370,11 @@
             su<lb ed="#F" n="28" break="no"/>biacet in septentrionem vertetur D. in austrum collimabit.
             <lb ed="#F" n="45" type="fixed=17"/>
                <figure xml:id="p9i7y5-de1603-Fd1e749">
-                  <graphic url="https://www.e-rara.ch/zut/i3f/v20/12869760/1085,535,1056,1249/full/0/default.jpg"/>
+                  <graphic url="https://www.e-rara.ch/zut/i3f/v20/12869760/1029,2136,1077,966/full/0/default.jpg"/>
                   <ab type="figure-details">
-                     <seg type="figure-text"/>
-                     <seg type="figure-ideas"/>
-                     <seg type="transkribus-id">900522-34375379-r6</seg>
+                     <seg type="figure-text"/> <!--no figure text-->
+                     <seg type="figure-ideas">magnetic force inclination concrete elements physical objects plasticity light/shadow integrated in the layout woodcut/>
+                     <seg type="transkribus-id">900522-34375379-r4</seg>
                   </ab>
                   <figDesc/>
                </figure>
@@ -388,7 +388,7 @@
             tan<lb ed="#F" n="33" break="no"/>gat.
          <lb ed="#F" n="46" type="fixed=17"/>
                <figure xml:id="p9i7y5-de1603-Fd1e783">
-                  <graphic url="https://www.e-rara.ch/zut/i3f/v20/12869760/1029,2136,1077,966/full/0/default.jpg"/>
+                  <graphic url="https://www.e-rara.ch/zut/i3f/v20/12869760/1085,535,1056,1249/full/0/default.jpg"/>
                   <ab type="figure-details">
                      <seg type="figure-text">F A D C E B</seg>
                      <seg type="figure-ideas">text light/shadow plasticity physical objects arrows letters concrete elements woodcut integrated in the layout 3d and perspective</seg>


### PR DESCRIPTION
I don't really understand why, but p9i7y5-de1603-Fd1e749 and p9i7y5-de1603-Fd1e783 got mixed up. They actually show the wrong image, therefore I changed the coords as well (but maybe this is not enough). See https://files.transkribus.eu/Get?id=ORVRDFXUHOMYPASXAKCZDTVT&fileType=view

The image with the compass and the magnet above is p9i7y5-de1603-Fd1e783, and the ball with the sticks below is p9i7y5-de1603-Fd1e749.